### PR TITLE
Fix Escort Duty clobbering start event, and breaking from 5.5 start event changes.

### DIFF
--- a/data/escort_scripts/escort-duty.lua
+++ b/data/escort_scripts/escort-duty.lua
@@ -250,8 +250,7 @@ end
 -----------------------------
 script.on_game_event("INITIAL_START_BEACON_ESCORT_DUTY", false, function() ShowTutorialArrow(1, 918, 561) end)
 script.on_game_event("INITIAL_START_BEACON_ESCORT_DUTY_ELITE", false, function() ShowTutorialArrow(1, 900, 561) end)
-script.on_game_event("LIGHTSPEED_DROPPOINT", false, HideTutorialArrow)
-script.on_game_event("START_BEACON_PRESELECT", false, HideTutorialArrow) -- Just in case the tut arrow is active on game start
+script.on_game_event("INITIAL_START_BEACON_ESCORT_DUTY_CANCEL", false, HideTutorialArrow)
 
 local function handle_mini_teleporters(linkageName)
     local ship = Hyperspace.ships.player

--- a/data/events_special_main.xml.append
+++ b/data/events_special_main.xml.append
@@ -1,65 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<mod:findName type="event" name="START_BEACON_PRESELECT" panic="true">
-    <!-- Jank way to make sure "Proceed with your mission" is always on top -->
-    <mod:findLike type="choice" start="1" limit="1">
-        <mod:setAttributes max_group="1" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="2" limit="1">
-        <mod:setAttributes max_group="2" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="3" limit="1">
-        <mod:setAttributes max_group="3" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="4" limit="1">
-        <mod:setAttributes max_group="4" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="5" limit="1">
-        <mod:setAttributes max_group="5" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="6" limit="1">
-        <mod:setAttributes max_group="6" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="7" limit="1">
-        <mod:setAttributes max_group="7" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="8" limit="1">
-        <mod:setAttributes max_group="8" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="9" limit="1">
-        <mod:setAttributes max_group="9" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="10" limit="1">
-        <mod:setAttributes max_group="10" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="11" limit="1">
-        <mod:setAttributes max_group="11" />
-    </mod:findLike>
-    <mod:findLike type="choice" start="12" limit="1">
-        <mod:setAttributes max_group="12" />
-    </mod:findLike>
-    
-    <!-- Custom start for escort duty -->
-    <mod:findWithChildLike type="choice" child-type="text" limit="1" panic="true">
-        <mod:selector>Proceed with your mission.</mod:selector>
-        <mod:setAttributes req="ALTERNATE_START" lvl="0" max_lvl="0" blue="false" />
-    </mod:findWithChildLike>
-    <mod-append:choice hidden="true" req="ESCORT_DUTY_ACTIVE" blue="false">
-        <text>Proceed with your mission.</text>
-        <event load="INITIAL_START_BEACON_ESCORT_DUTY"/>
-    </mod-append:choice>
-    <mod-append:choice hidden="true" req="SHIP ELITE_SHIP_ESCORT_DUTY" blue="false">
-        <text>Proceed with your mission.</text>
-        <event load="INITIAL_START_BEACON_ESCORT_DUTY_ELITE"/>
-    </mod-append:choice>
+<mod:findName type="event" name="START_BEACON_REAL" limit="1">
+	<mod-append:queueEvent>OG_TURRET_ARROWS_START</mod-append:queueEvent>
 </mod:findName>
+
+<event name="OG_TURRET_ARROWS_START">
+	<loadEventList seeded="false" first="true" generate="false" default="INITIAL_START_BEACON_ESCORT_DUTY_CANCEL">
+		<event name="INITIAL_START_BEACON_ESCORT_DUTY" req="ESCORT_DUTY_ACTIVE" lvl="1"/>
+		<event name="INITIAL_START_BEACON_ESCORT_DUTY_ELITE" req="SHIP ELITE_SHIP_ESCORT_DUTY" lvl="1"/>
+	</loadEventList>
+</event>
+<event name="INITIAL_START_BEACON_ESCORT_DUTY_CANCEL"/>
 
 <event name="INITIAL_START_BEACON_ESCORT_DUTY">
     <text>Your ships are equipped with a pair of short-range transporters. When activated, crew on the pads will be teleported to the pads on the other ship. They cannot be damaged, but require 5 seconds to recharge after being used.</text>
-    <choice hidden="true">
-        <text>Continue...</text>
-        <event load="LIGHTSPEED_DROPPOINT"/>
-    </choice>
     <eventButton name="UI_ESCORT_TELEPORT">
         <event load="LUA_ESCORT_TELEPORT"/>
         <image>statusUI/escort_tp</image>
@@ -73,11 +27,6 @@
 
 <event name="INITIAL_START_BEACON_ESCORT_DUTY_ELITE">
     <text>Your ships are equipped with two pairs of short-range transporters. When activated, crew on the pads will be teleported to the corresponding pads on the other ship. They cannot be damaged, but require 5 seconds to recharge after being used.</text>
-    <remove name="SHARED_SYSTEMS"/>
-    <choice hidden="true">
-        <text>Continue...</text>
-        <event load="LIGHTSPEED_DROPPOINT"/>
-    </choice>
     <eventButton name="UI_ESCORT_TELEPORT">
         <event load="LUA_ESCORT_TELEPORT"/>
         <image>statusUI/escort_tp</image>

--- a/data/events_special_main.xml.append
+++ b/data/events_special_main.xml.append
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <mod:findName type="event" name="START_BEACON_REAL" limit="1">
-	<mod-append:queueEvent>OG_TURRET_ARROWS_START</mod-append:queueEvent>
+	<mod-append:queueEvent>INITIAL_START_BEACON_ESCORT_DUTY_LOAD</mod-append:queueEvent>
 </mod:findName>
 
-<event name="OG_TURRET_ARROWS_START">
+<event name="INITIAL_START_BEACON_ESCORT_DUTY_LOAD">
 	<loadEventList seeded="false" first="true" generate="false" default="INITIAL_START_BEACON_ESCORT_DUTY_CANCEL">
 		<event name="INITIAL_START_BEACON_ESCORT_DUTY" req="ESCORT_DUTY_ACTIVE" lvl="1"/>
 		<event name="INITIAL_START_BEACON_ESCORT_DUTY_ELITE" req="SHIP ELITE_SHIP_ESCORT_DUTY" lvl="1"/>

--- a/data/events_special_main.xml.append
+++ b/data/events_special_main.xml.append
@@ -14,6 +14,10 @@
 
 <event name="INITIAL_START_BEACON_ESCORT_DUTY">
     <text>Your ships are equipped with a pair of short-range transporters. When activated, crew on the pads will be teleported to the pads on the other ship. They cannot be damaged, but require 5 seconds to recharge after being used.</text>
+    <choice>
+        <text>Continue...</text>
+        <event load="INITIAL_START_BEACON_ESCORT_DUTY_CANCEL"/>
+    </choice>
     <eventButton name="UI_ESCORT_TELEPORT">
         <event load="LUA_ESCORT_TELEPORT"/>
         <image>statusUI/escort_tp</image>
@@ -27,6 +31,10 @@
 
 <event name="INITIAL_START_BEACON_ESCORT_DUTY_ELITE">
     <text>Your ships are equipped with two pairs of short-range transporters. When activated, crew on the pads will be teleported to the corresponding pads on the other ship. They cannot be damaged, but require 5 seconds to recharge after being used.</text>
+    <choice>
+        <text>Continue...</text>
+        <event load="INITIAL_START_BEACON_ESCORT_DUTY_CANCEL"/>
+    </choice>
     <eventButton name="UI_ESCORT_TELEPORT">
         <event load="LUA_ESCORT_TELEPORT"/>
         <image>statusUI/escort_tp</image>
@@ -46,6 +54,7 @@
         <jumpClear>false</jumpClear>
     </eventButton>
 </event>
+
 
 <event name="LUA_ESCORT_TELEPORT">
     <triggeredEvent event="ESCORT_TELEPORT_RECHARGE" minTime="5.0" maxTime="5.0"/>

--- a/mod-appendix/metadata.xml
+++ b/mod-appendix/metadata.xml
@@ -1,8 +1,8 @@
 <metadata>
     <title><![CDATA[ Escort Duty for Multiverse ]]></title>
     <threadUrl><![CDATA[ https://www.subsetgames.com/forum/viewtopic.php?t=38378#p129863 ]]></threadUrl>
-    <author><![CDATA[ Chrono Vortex, DryEagle, Vertaalfout, RAD-82 ]]></author>
-    <version><![CDATA[ 4.5 ]]></version>
+    <author><![CDATA[ Chrono Vortex, DryEagle, Vertaalfout, RAD-82, Arc ]]></author>
+    <version><![CDATA[ 4.6 ]]></version>
     <description>
 <![CDATA[
 One of the classics from DryEagle, the original version of this mod pushed the bounds of what was possible in FTL long before Hyperspace came around. Now given a fresh coat of paint and enhanced with some of that Hyperspace magic, this ship and its charge are ready to explore the Multiverse!


### PR DESCRIPTION
Use queueEvent to add the escort duty tutorial to the event queue to show up after the start, this prevents escort duty from breaking other addons and makes it much more resiliant to event changes in MV.